### PR TITLE
Add tests for Sort/compare ability

### DIFF
--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -11,7 +11,84 @@ use indoc::indoc;
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn compare_u64() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : U64
+                i = 1
+
+                j : U64
+                j = 2
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        2,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : U64
+                i = 2
+
+                j : U64
+                j = 1
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        1,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : U64
+                i = 1
+
+                j : U64
+                j = 1
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn compare_i64() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : I64
+                i = -1
+
+                j : I64
+                j = 1
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        2,
+        u8
+    );
     assert_evals_to!(
         indoc!(
             r#"
@@ -19,15 +96,151 @@ fn compare_i64() {
                 i = 1
 
                 j : I64
-                j = 2
+                j = -1
 
                 when List.compare i j is
-                    Equals -> 0
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        1,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : I64
+                i = -1
+
+                j : I64
+                j = -1
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn compare_f64() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : F64
+                i = 1.2
+
+                j : F64
+                j = 1.3
+
+                when List.compare i j is
+                    Equal -> 0
                     GreaterThan -> 1
                     LessThan -> 2
             "#
         ),
         2,
-        i64
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : F64
+                i = 1.3
+
+                j : F64
+                j = 1.2
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        1,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : F64
+                i = 1.2
+
+                j : F64
+                j = 1.2
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn compare_bool() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : Bool
+                i = Bool.false
+
+                j : Bool
+                j = Bool.true
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        2,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : Bool
+                i = Bool.true
+
+                j : Bool
+                j = Bool.false
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        1,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : Bool
+                i = Bool.false
+
+                j : Bool
+                j = Bool.false
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
     );
 }


### PR DESCRIPTION
We had a single test before, but it was failing due to a typo. This fixes the test, plus adds some more for the new sortable types we've added since.

To run just these tests, use this command:

```
cargo test-gen-llvm gen_compare -- --nocapture
```