### PR TITLE
Implemented compare (for Sort ability) for structs

### DIFF
--- a/crates/compiler/module/src/symbol.rs
+++ b/crates/compiler/module/src/symbol.rs
@@ -1198,6 +1198,8 @@ define_builtins! {
         31 ATTR_INVALID: "#attr_invalid"
 
         32 CLONE: "#clone" // internal function that clones a value into a buffer
+
+        33 GENERIC_COMPARE: "#generic_compare" // internal function which compares two values, returning 0, 1, or 2 for ==, >, or <
     }
     // Fake module for synthesizing and storing derived implementations
     1 DERIVED_SYNTH: "#Derived" => {

--- a/crates/compiler/test_gen/src/gen_compare.rs
+++ b/crates/compiler/test_gen/src/gen_compare.rs
@@ -247,6 +247,137 @@ fn compare_bool() {
 
 #[test]
 #[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
+fn compare_struct() {
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { a : Bool }
+                i = { a : Bool.false }
+
+                j : { a : Bool }
+                j = { a : Bool.false }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { a : Bool }
+                i = { a : Bool.true }
+
+                j : { a : Bool }
+                j = { a : Bool.false }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        1,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { a : I64 }
+                i = { a : 2 }
+
+                j : { a : I64 }
+                j = { a  : 3 }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        2,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { a : Bool, b : F32}
+                i = { a : Bool.false, b : 1.2 }
+
+                j : { a : Bool, b : F32 }
+                j = { a : Bool.false, b : 1.3 }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        2,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { a : Bool, b : List F32}
+                i = { a : Bool.false, b : [1.3] }
+
+                j : { a : Bool, b : List F32 }
+                j = { a : Bool.false, b : [1.2] }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        1,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { a : Bool, b : List U32}
+                i = { a : Bool.false, b : [13] }
+
+                j : { a : Bool, b : List U32 }
+                j = { a : Bool.false, b : [13] }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
+    );
+    assert_evals_to!(
+        indoc!(
+            r#"
+                i : { }
+                i = { }
+
+                j : { }
+                j = { }
+
+                when List.compare i j is
+                    Equal -> 0
+                    GreaterThan -> 1
+                    LessThan -> 2
+            "#
+        ),
+        0,
+        u8
+    );
+}
+
+#[test]
+#[cfg(any(feature = "gen-llvm", feature = "gen-dev", feature = "gen-wasm"))]
 fn list() {
     assert_evals_to!(
         indoc!(


### PR DESCRIPTION
This implementation of compare for structs was, like my previous work, mostly copying existing code and making the minimum changes for it to work in my context. But now I have noticed an inconsistency in the code I am copying.

In the `build_list_eq()` function I previously copied from, the `LayoutRepr` for the elements is updated with the following code:
```
let element_layout = if let LayoutRepr::RecursivePointer(rec) = element_layout {
    layout_interner.get_repr(rec)
} else {
    element_layout
};
```
In the `build_struct_eq()` function I copy from for this PR, if the `LayoutRepr` for the elements is a `RecursivePointer`, the element pointers are cast before use:
```
if let LayoutRepr::RecursivePointer(rec_layout) = layout_interner.get_repr(*field_layout)
{
    debug_assert!(
        matches!(layout_interner.get_repr(rec_layout), LayoutRepr::Union(union_layout) if !matches!(union_layout, UnionLayout::NonRecursive(..)))
    );

    let field_layout = rec_layout;

    let bt = basic_type_from_layout(
        env,
        layout_interner,
        layout_interner.get_repr(field_layout),
    );

    // cast the i64 pointer to a pointer to block of memory
    let field1_cast = env.builder.new_build_pointer_cast(
        field1.into_pointer_value(),
        bt.into_pointer_type(),
        "i64_to_opaque",
    );

    let field2_cast = env.builder.new_build_pointer_cast(
        field2.into_pointer_value(),
        bt.into_pointer_type(),
        "i64_to_opaque",
    );
...
```
If both those places are correct, I would like to better understand why they need to be different. If one of those places is wrong, we will need to update that place and the place I copied the erroneous code to.
